### PR TITLE
Only mark the input as consumed once it is no longer required

### DIFF
--- a/lib/fft_burst_tagger_impl.cc
+++ b/lib/fft_burst_tagger_impl.cc
@@ -1104,11 +1104,10 @@ int fft_burst_tagger_impl::general_work(int noutput_items,
         usleep(100);
     }
 
-    consume_each(consumed);
-
     if (produced) {
         memcpy(out, in, sizeof(gr_complex) * produced);
     }
+    consume_each(consumed);
     return produced;
 }
 


### PR DESCRIPTION
This was a pretty awesome bug to track down.   When running the same data file over and over, different results would be had.   I believe the actual call to consume must tell GNURadio we no longer care about the input buffer.   This left a small timing window where corrupt data was getting passed to the next block from the burst tagger.